### PR TITLE
Keeping track of nodes locations during parsing.

### DIFF
--- a/json-overlay/src/main/java/com/reprezen/jsonoverlay/parser/JsonRegion.java
+++ b/json-overlay/src/main/java/com/reprezen/jsonoverlay/parser/JsonRegion.java
@@ -1,0 +1,28 @@
+package com.reprezen.jsonoverlay.parser;
+
+import com.fasterxml.jackson.core.JsonLocation;
+import com.fasterxml.jackson.core.JsonPointer;
+
+public class JsonRegion {
+	private final JsonPointer pointer;
+	private final JsonLocation start;
+	private final JsonLocation end;
+
+	public JsonRegion(JsonPointer pointer, JsonLocation start, JsonLocation end) {
+		this.pointer = pointer;
+		this.start = start;
+		this.end = end;
+	}
+
+	public JsonPointer getPointer() {
+		return pointer;
+	}
+
+	public JsonLocation getStart() {
+		return start;
+	}
+
+	public JsonLocation getEnd() {
+		return end;
+	}
+}

--- a/json-overlay/src/main/java/com/reprezen/jsonoverlay/parser/LocationProcessor.java
+++ b/json-overlay/src/main/java/com/reprezen/jsonoverlay/parser/LocationProcessor.java
@@ -1,0 +1,92 @@
+package com.reprezen.jsonoverlay.parser;
+
+import com.fasterxml.jackson.core.JsonLocation;
+import com.fasterxml.jackson.core.JsonPointer;
+import com.fasterxml.jackson.core.JsonStreamContext;
+import com.fasterxml.jackson.core.JsonToken;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+
+import java.util.Map;
+
+public class LocationProcessor {
+
+	private final Map<JsonPointer, JsonRegion> locations = Maps.newHashMap();
+
+	private JsonPointer ptr = JsonPointer.compile("");
+	private boolean seenRoot = false;
+
+	LocationProcessor() {
+	}
+
+	public Map<JsonPointer, JsonRegion> getLocations() {
+		return ImmutableMap.copyOf(locations);
+	}
+
+	public void processTokenLocation(JsonToken token, JsonLocation location, JsonStreamContext context) {
+
+		/*
+		 * Handle root of document. We create a region that contains the whole document.
+		 */
+		if (!seenRoot) {
+			locations.put(ptr, new JsonRegion(ptr, location, location));
+			seenRoot = true;
+			return;
+		}
+
+		/*
+		 * We have reached end of document, so we update the root region end location.
+		 */
+		if (context.inRoot()) {
+			JsonRegion region = locations.get(ptr);
+			locations.put(ptr, new JsonRegion(region.getPointer(), region.getStart(), location));
+			return;
+		}
+
+		/*
+		 * If the end of a container, we update the end location of it's region and update the
+		 * pointer to it's parent.
+		 */
+		if (token == JsonToken.END_OBJECT || token == JsonToken.END_ARRAY) {
+			JsonRegion region = locations.get(ptr);
+			locations.put(ptr, new JsonRegion(region.getPointer(), region.getStart(), location));
+
+			ptr = ptr.head();
+
+			return;
+		}
+
+		/*
+		 * Nothing to do with fields.
+		 */
+		if (token == JsonToken.FIELD_NAME) {
+			return;
+		}
+
+		final JsonStreamContext parent = context.getParent();
+
+		/*
+		 * Beginning of a container.
+		 */
+		if (token == JsonToken.START_ARRAY || token == JsonToken.START_OBJECT) {
+			ptr = getPointer(parent, ptr);
+			locations.put(ptr, new JsonRegion(ptr, location, location));
+			return;
+		}
+
+		/*
+		 * Normal case, build a region for the pointer.
+		 */
+		final JsonPointer entryPointer = getPointer(context, ptr);
+
+		JsonRegion range = new JsonRegion(entryPointer, location, location);
+		locations.put(entryPointer, range);
+	}
+
+	private JsonPointer getPointer(JsonStreamContext context, JsonPointer ptr) {
+		if (context.inArray())
+			return ptr.append(JsonPointer.compile("/" + context.getCurrentIndex()));
+		else
+			return ptr.append(JsonPointer.compile("/" + context.getCurrentName()));
+	}
+}

--- a/json-overlay/src/main/java/com/reprezen/jsonoverlay/parser/LocationRecorderJsonFactory.java
+++ b/json-overlay/src/main/java/com/reprezen/jsonoverlay/parser/LocationRecorderJsonFactory.java
@@ -1,0 +1,28 @@
+package com.reprezen.jsonoverlay.parser;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.io.IOContext;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+
+public final class LocationRecorderJsonFactory extends JsonFactory {
+
+	@Override
+	protected JsonParser _createParser(InputStream in, IOContext ctxt) throws IOException {
+		return new LocationRecorderJsonParser(super._createParser(in, ctxt));
+	}
+
+	@Override
+	protected JsonParser _createParser(Reader r, IOContext ctxt) throws IOException {
+		return new LocationRecorderJsonParser(super._createParser(r, ctxt));
+	}
+
+	@Override
+	protected JsonParser _createParser(byte[] data, int offset, int len, IOContext ctxt) throws IOException {
+		return new LocationRecorderJsonParser(super._createParser(data, offset, len, ctxt));
+	}
+
+}

--- a/json-overlay/src/main/java/com/reprezen/jsonoverlay/parser/LocationRecorderJsonParser.java
+++ b/json-overlay/src/main/java/com/reprezen/jsonoverlay/parser/LocationRecorderJsonParser.java
@@ -1,0 +1,31 @@
+package com.reprezen.jsonoverlay.parser;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonPointer;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.util.JsonParserDelegate;
+
+import java.io.IOException;
+import java.util.Map;
+
+public final class LocationRecorderJsonParser extends JsonParserDelegate {
+
+	private final LocationProcessor processor = new LocationProcessor();
+
+	public LocationRecorderJsonParser(final JsonParser d) {
+		super(d);
+	}
+
+	@Override
+	public JsonToken nextToken() throws IOException {
+		JsonToken token = super.nextToken();
+		processor.processTokenLocation(token, getCurrentLocation(), getParsingContext());
+
+		return token;
+	}
+
+	public Map<JsonPointer, JsonRegion> getLocations() {
+		return processor.getLocations();
+	}
+
+}

--- a/json-overlay/src/main/java/com/reprezen/jsonoverlay/parser/LocationRecorderYamlFactory.java
+++ b/json-overlay/src/main/java/com/reprezen/jsonoverlay/parser/LocationRecorderYamlFactory.java
@@ -1,0 +1,22 @@
+package com.reprezen.jsonoverlay.parser;
+
+import com.fasterxml.jackson.core.io.IOContext;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLParser;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+
+public class LocationRecorderYamlFactory extends YAMLFactory {
+
+	@Override
+	protected YAMLParser _createParser(InputStream in, IOContext ctxt) throws IOException {
+		return new LocationRecorderYamlParser(ctxt, _getBufferRecycler(), _parserFeatures, _yamlParserFeatures, _objectCodec, _createReader(in, null, ctxt));
+	}
+
+	@Override
+	protected YAMLParser _createParser(Reader r, IOContext ctxt) {
+		return new LocationRecorderYamlParser(ctxt, _getBufferRecycler(), _parserFeatures, _yamlParserFeatures, _objectCodec, r);
+	}
+}

--- a/json-overlay/src/main/java/com/reprezen/jsonoverlay/parser/LocationRecorderYamlParser.java
+++ b/json-overlay/src/main/java/com/reprezen/jsonoverlay/parser/LocationRecorderYamlParser.java
@@ -1,0 +1,33 @@
+package com.reprezen.jsonoverlay.parser;
+
+import com.fasterxml.jackson.core.JsonPointer;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.core.io.IOContext;
+import com.fasterxml.jackson.core.util.BufferRecycler;
+import com.fasterxml.jackson.dataformat.yaml.YAMLParser;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.util.Map;
+
+public class LocationRecorderYamlParser extends YAMLParser {
+
+	private final LocationProcessor processor = new LocationProcessor();
+
+	public LocationRecorderYamlParser(IOContext ctxt, BufferRecycler br, int parserFeatures, int formatFeatures, ObjectCodec codec, Reader reader) {
+		super(ctxt, br, parserFeatures, formatFeatures, codec, reader);
+	}
+
+	public Map<JsonPointer, JsonRegion> getLocations() {
+		return processor.getLocations();
+	}
+
+	@Override
+	public JsonToken nextToken() throws IOException {
+		JsonToken token = super.nextToken();
+		processor.processTokenLocation(token, getCurrentLocation(), getParsingContext());
+
+		return token;
+	}
+}

--- a/json-overlay/src/test/java/com/reprezen/jsonoverlay/test/LocationTest.java
+++ b/json-overlay/src/test/java/com/reprezen/jsonoverlay/test/LocationTest.java
@@ -1,0 +1,35 @@
+package com.reprezen.jsonoverlay.test;
+
+import com.fasterxml.jackson.core.JsonPointer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.io.Resources;
+import com.reprezen.jsonoverlay.JsonLoader;
+import com.reprezen.jsonoverlay.parser.JsonRegion;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class LocationTest {
+
+	@Test
+	public void testYamlLocation() throws IOException {
+		Pair<JsonNode, Map<JsonPointer, JsonRegion>> result = new JsonLoader().loadWithLocations(Resources.toString(
+				Resources.getResource("referenceTests/main.yaml"), Charset.forName("utf8")));
+
+		Map<JsonPointer, JsonRegion> locations = result.getRight();
+
+		assertTrue(locations.containsKey(JsonPointer.compile("/map/a")));
+
+		JsonRegion region = locations.get(JsonPointer.compile("/map/a"));
+		assertEquals(5, region.getStart().getLineNr());
+		assertEquals(5, region.getStart().getColumnNr());
+		assertEquals(6, region.getEnd().getLineNr());
+		assertEquals(3, region.getEnd().getColumnNr());
+	}
+}


### PR DESCRIPTION
This is a proof of concept implementation showing how JSON and Yaml parsers can be modified to keep track of nodes locations. The locations are stored in a JsonRegion that is identified by a JsonPointer and a start and end locations.

@andylowry Adding locations would make it possible to use KZOP in Kaizen Editor.