### PR TITLE
[#20] Remove commons.io from pom file

### DIFF
--- a/json-overlay/pom.xml
+++ b/json-overlay/pom.xml
@@ -67,11 +67,6 @@
 			<version>2.8.4</version>
 		</dependency>
 		<dependency>
-			<groupId>commons-io</groupId>
-			<artifactId>commons-io</artifactId>
-			<version>2.5</version>
-		</dependency>
-		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
 			<version>3.5</version>


### PR DESCRIPTION
Prior change removed imports, but mistakenly left the dependency in
place.