### PR TITLE
[#24] Fix constructors for subtypes

### DIFF
--- a/json-overlay/src/main/java/com/reprezen/jsonoverlay/gen/ImplGenerator.xtend
+++ b/json-overlay/src/main/java/com/reprezen/jsonoverlay/gen/ImplGenerator.xtend
@@ -109,12 +109,12 @@ class ImplGenerator extends TypeGenerator {
 		requireTypes(JsonNode, JsonOverlay)
 		members.addMember('''
 			public «type.implType»(JsonNode json, JsonOverlay<?> parent, ReferenceManager refMgr) {
-				super(json, parent, factory, refMgr);
+				super(json, parent, «IF type.extensionOf == null»factory, «ENDIF»refMgr);
 			}
 		''')
 		members.addMember('''
 			public «type.implType»(«type.name» «type.lcName», JsonOverlay<?> parent, ReferenceManager refMgr) {
-				super(«type.lcName», parent, factory, refMgr);
+				super(«type.lcName», parent, «IF type.extensionOf == null»factory, «ENDIF»refMgr);
 			}
 		''')
 		return members
@@ -425,7 +425,7 @@ class ImplGenerator extends TypeGenerator {
 				switch (subtype != null ? subtype.getSimpleName() : "") {
 					«FOR sub : subtypes»
 						case "«sub.name»":
-							overlay = «sub.implType».factory.create(«sub.castArg0(arg0)», parent, refMgr, null);
+							overlay = «sub.implType».factory.create(«sub.castArg0(arg0)», parent, refMgr);
 							break;
 					«ENDFOR»
 					default:


### PR DESCRIPTION
PropertiesOverlay now requires a factory in its constructors, so direct
subclasses need to include it in their super-constructor
invocations. But types that are extensions of other types need to omit
the factory, since their supertype constructors don't have it in their
signatures, so passing them causes compilation errors.

Also, factory create calls for subtypes still had null reference args,
which are no longer in the method signatures, so more compilation errors.