### PR TITLE
Task/32 Fix position info

### DIFF
--- a/json-overlay/src/main/java/com/reprezen/jsonoverlay/Overlay.java
+++ b/json-overlay/src/main/java/com/reprezen/jsonoverlay/Overlay.java
@@ -392,4 +392,9 @@ public class Overlay<V> {
 			return null;
 		}
 	}
+
+	@Override
+	public String toString() {
+		return overlay.toString();
+	}
 }

--- a/json-overlay/src/main/java/com/reprezen/jsonoverlay/StringOverlay.java
+++ b/json-overlay/src/main/java/com/reprezen/jsonoverlay/StringOverlay.java
@@ -37,6 +37,13 @@ public final class StringOverlay extends ScalarOverlay<String> {
 		return factory;
 	}
 
+	@Override
+	public String toString() {
+		// we don't want quotes here; the default rendering uses toJson, which does
+		// include them.
+		return value != null ? value : "";
+	}
+
 	public static OverlayFactory<String> factory = new OverlayFactory<String>() {
 
 		@Override

--- a/json-overlay/src/main/java/com/reprezen/jsonoverlay/parser/LocationProcessor.java
+++ b/json-overlay/src/main/java/com/reprezen/jsonoverlay/parser/LocationProcessor.java
@@ -1,12 +1,13 @@
 package com.reprezen.jsonoverlay.parser;
 
+import java.util.ArrayDeque;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.Map;
 
 import com.fasterxml.jackson.core.JsonLocation;
 import com.fasterxml.jackson.core.JsonPointer;
-import com.fasterxml.jackson.core.JsonStreamContext;
 import com.fasterxml.jackson.core.JsonToken;
 import com.reprezen.jsonoverlay.PositionInfo;
 
@@ -14,83 +15,188 @@ public class LocationProcessor {
 
 	private final Map<JsonPointer, PositionInfo> locations = new HashMap<>();
 
-	private JsonPointer ptr = JsonPointer.compile("");
-	private boolean seenRoot = false;
+	private Deque<Context> contextStack = new ArrayDeque<Context>();
+	private Context context; // current context, never on the stack
 
 	LocationProcessor() {
+		context = new RootContext();
 	}
 
 	public Map<JsonPointer, PositionInfo> getLocations() {
 		return Collections.unmodifiableMap(locations);
 	}
 
-	public void processTokenLocation(JsonToken token, JsonLocation tokenStart, JsonLocation tokenEnd,
-			JsonStreamContext context) {
+	public void processTokenLocation(JsonToken token, String name, JsonLocation tokenStart, JsonLocation tokenEnd) {
+		switch (token) {
+		case FIELD_NAME:
+			context.setNextProp(name);
+			break;
 
-		final JsonStreamContext parent = context.getParent();
+		case START_OBJECT:
+			context.startValue();
+			contextStack.push(context);
+			context = new ObjectContext(context, tokenStart);
+			break;
 
-		/*
-		 * Handle root of document. We create a region that contains the whole document.
-		 */
-		if (!seenRoot) {
-			locations.put(ptr, new PositionInfo(ptr, tokenStart, tokenStart));
-			seenRoot = true;
-			return;
+		case END_OBJECT:
+			recordInfo(context, tokenEnd);
+			if (!(context instanceof ObjectContext)) {
+				throw new IllegalStateException();
+			}
+			context = contextStack.pop();
+			break;
+
+		case START_ARRAY:
+			context.startValue();
+			contextStack.push(context);
+			context = new ArrayContext(context, tokenStart);
+			break;
+
+		case END_ARRAY:
+			recordInfo(context, tokenEnd);
+			if (!(context instanceof ArrayContext)) {
+				throw new IllegalStateException();
+			}
+			context = contextStack.pop();
+			break;
+
+		case NOT_AVAILABLE:
+		case VALUE_EMBEDDED_OBJECT:
+			throw new IllegalStateException();
+
+		default: // all the other cases represent scalar values
+			context.startValue();
+			recordInfo(context.getChildPointer(), tokenStart, tokenEnd);
+			break;
 		}
-
-		/*
-		 * We have reached end of document, so we update the root region end location.
-		 */
-		if (context.inRoot()) {
-			PositionInfo region = locations.get(ptr);
-			locations.put(ptr, new PositionInfo(region.getPointer(), region.getStart(), tokenEnd));
-			return;
-		}
-
-		/*
-		 * Beginning of a container.
-		 */
-		if (token == JsonToken.START_ARRAY || token == JsonToken.START_OBJECT) {
-			ptr = getPointer(parent, ptr);
-			locations.put(ptr, new PositionInfo(ptr, tokenEnd, tokenEnd));
-			return;
-		}
-
-		/*
-		 * If the end of a container, we update the end location of it's region and
-		 * update the pointer to it's parent.
-		 */
-		if (token == JsonToken.END_OBJECT || token == JsonToken.END_ARRAY) {
-			PositionInfo region = locations.get(ptr);
-			locations.put(ptr, new PositionInfo(region.getPointer(), region.getStart(), tokenEnd));
-
-			ptr = ptr.head();
-
-			return;
-		}
-
-		/*
-		 * Nothing to do with fields.
-		 */
-		if (token == JsonToken.FIELD_NAME) {
-		}
-
-		/*
-		 * Normal case, build a region for the pointer.
-		 */
-		final JsonPointer entryPointer = getPointer(context, ptr);
-		PositionInfo range = new PositionInfo(entryPointer, tokenStart, tokenEnd);
-		locations.put(entryPointer, range);
 	}
 
-	private JsonPointer getPointer(JsonStreamContext context, JsonPointer ptr) {
-		if (context.inArray())
-			return ptr.append(JsonPointer.compile("/" + context.getCurrentIndex()));
-		else
-			return ptr.append(JsonPointer.compile("/" + encode(context.getCurrentName())));
+	private void recordInfo(Context context, JsonLocation end) {
+		recordInfo(context.getPointer(), context.getStart(), end);
 	}
 
-	private String encode(String name) {
-		return name.replaceAll("~", "~0").replaceAll("/", "~1");
+	private void recordInfo(JsonPointer ptr, JsonLocation start, JsonLocation end) {
+		PositionInfo pos = new PositionInfo(ptr, start, end);
+		locations.put(ptr, pos);
+	}
+
+	private static abstract class Context {
+		protected JsonPointer ptr;
+		protected JsonLocation start;
+		protected JsonLocation end;
+
+		public Context(JsonPointer ptr, JsonLocation start, JsonLocation end) {
+			super();
+			this.ptr = ptr;
+			this.start = start;
+			this.end = end;
+		}
+
+		public JsonPointer getPointer() {
+			return ptr;
+		}
+
+		public JsonLocation getStart() {
+			return start;
+		}
+
+		public JsonLocation getEnd() {
+			return end;
+		}
+
+		public abstract JsonPointer getChildPointer();
+
+		public abstract void startValue();
+
+		public abstract void setNextProp(String name);
+	}
+
+	private static class RootContext extends Context {
+		public RootContext() {
+			super(JsonPointer.compile(""), null, null);
+		}
+
+		@Override
+		public JsonPointer getChildPointer() {
+			return ptr;
+		}
+
+		@Override
+		public void startValue() {
+		}
+
+		@Override
+		public void setNextProp(String name) {
+			throw new IllegalStateException();
+		}
+	}
+
+	private static class ObjectContext extends Context {
+		private String currentProp = null;
+		private String nextProp = null;
+
+		public ObjectContext(Context parent, JsonLocation start) {
+			super(parent.getChildPointer(), start, null);
+		}
+
+		@Override
+		public JsonPointer getChildPointer() {
+			if (currentProp != null) {
+				JsonPointer child = JsonPointer.compile("/" + encode(currentProp));
+				return ptr.append(child);
+			} else {
+				throw new IllegalStateException();
+			}
+		}
+
+		private String encode(String s) {
+			return s.replaceAll("~", "~0").replaceAll("/", "~1");
+		}
+
+		@Override
+		public void startValue() {
+			if (nextProp != null) {
+				this.currentProp = nextProp;
+				nextProp = null;
+			} else {
+				throw new IllegalStateException();
+			}
+		}
+
+		@Override
+		public void setNextProp(String name) {
+			if (nextProp == null) {
+				this.nextProp = name;
+			} else {
+				throw new IllegalStateException();
+			}
+		}
+	}
+
+	private static class ArrayContext extends Context {
+		private int currentIndex = -1;
+
+		public ArrayContext(Context parent, JsonLocation start) {
+			super(parent.getChildPointer(), start, null);
+		}
+
+		@Override
+		public JsonPointer getChildPointer() {
+			if (currentIndex >= 0) {
+				return ptr.append(JsonPointer.compile("/" + currentIndex));
+			} else {
+				throw new IllegalStateException();
+			}
+		}
+
+		@Override
+		public void startValue() {
+			this.currentIndex += 1;
+		}
+
+		@Override
+		public void setNextProp(String name) {
+			throw new IllegalStateException();
+		}
 	}
 }

--- a/json-overlay/src/main/java/com/reprezen/jsonoverlay/parser/LocationRecorderYamlParser.java
+++ b/json-overlay/src/main/java/com/reprezen/jsonoverlay/parser/LocationRecorderYamlParser.java
@@ -1,5 +1,7 @@
 package com.reprezen.jsonoverlay.parser;
 
+import static com.fasterxml.jackson.core.JsonToken.FIELD_NAME;
+
 import java.io.IOException;
 import java.io.Reader;
 import java.util.Map;
@@ -29,10 +31,10 @@ public class LocationRecorderYamlParser extends YAMLParser {
 	@Override
 	public JsonToken nextToken() throws IOException {
 		JsonToken token = super.nextToken();
+		String fieldName = token == FIELD_NAME ? getCurrentName() : null;
 		JsonLocation tokenStart = getTokenLocation();
 		JsonLocation tokenEnd = getCurrentLocation();
-		processor.processTokenLocation(token, tokenStart, tokenEnd, getParsingContext());
-
+		processor.processTokenLocation(token, fieldName, tokenStart, tokenEnd);
 		return token;
 	}
 }


### PR DESCRIPTION
JsonParser's parser context object was supplying bogus data. I guess that don't use that data internally. Anyway, we no longer use their context object, but we keep a stack of our own "context" objects, and things are far more reliable.

Also threw in a sneak that's cherry-picked from another in-progress branch, making  Overlay.toString() delegate to its JsonOverlay object. This immediately makes many validation messages more intelligible.