### PR TITLE
[#38] Remove norconex commons-lang library

### DIFF
--- a/json-overlay/pom.xml
+++ b/json-overlay/pom.xml
@@ -76,11 +76,6 @@
 			<artifactId>org.eclipse.xtend.lib</artifactId>
 			<version>2.11.0</version>
 		</dependency>
-		<dependency>
-			<groupId>com.norconex.commons</groupId>
-			<artifactId>norconex-commons-lang</artifactId>
-			<version>1.15.0</version>
-		</dependency>
 	</dependencies>
 	<profiles>
 		<profile>

--- a/json-overlay/src/main/java/com/reprezen/jsonoverlay/JsonLoader.java
+++ b/json-overlay/src/main/java/com/reprezen/jsonoverlay/JsonLoader.java
@@ -18,8 +18,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Scanner;
 
-import org.apache.commons.lang3.tuple.Pair;
-
 import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;

--- a/json-overlay/src/main/java/com/reprezen/jsonoverlay/Pair.java
+++ b/json-overlay/src/main/java/com/reprezen/jsonoverlay/Pair.java
@@ -1,0 +1,23 @@
+package com.reprezen.jsonoverlay;
+
+public class Pair<L, R> {
+	private L left;
+	private R right;
+
+	public Pair(L left, R right) {
+		this.left = left;
+		this.right = right;
+	}
+
+	public static <XL, XR> Pair<XL, XR> of(XL left, XR right) {
+		return new Pair<XL, XR>(left, right);
+	}
+
+	public L getLeft() {
+		return left;
+	}
+
+	public R getRight() {
+		return right;
+	}
+}

--- a/json-overlay/src/main/java/com/reprezen/jsonoverlay/ReferenceManager.java
+++ b/json-overlay/src/main/java/com/reprezen/jsonoverlay/ReferenceManager.java
@@ -2,6 +2,8 @@ package com.reprezen.jsonoverlay;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
@@ -9,7 +11,6 @@ import java.util.Optional;
 
 import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.norconex.commons.lang.url.URLNormalizer;
 
 public class ReferenceManager {
 
@@ -94,17 +95,17 @@ public class ReferenceManager {
 
 	private static URL normalize(URL url, boolean noFrag) {
 		if (url != null) {
-			URLNormalizer normalizer = new URLNormalizer(url.toString()) //
-					.lowerCaseSchemeHost() //
-					.upperCaseEscapeSequence() //
-					.decodeUnreservedCharacters() //
-					.removeDefaultPort() //
-					.encodeNonURICharacters() //
-					.removeDotSegments();
-			if (noFrag) {
-				normalizer = normalizer.removeFragment();
+			String urlString = url.toString();
+			int fragPos = urlString.indexOf("#");
+			if (noFrag && fragPos >= 0) {
+				urlString = urlString.substring(0, fragPos);
 			}
-			return normalizer.toURL();
+			try {
+				return new URI(urlString).normalize().toURL();
+			} catch (MalformedURLException | URISyntaxException e) {
+				// oh well, we tried...
+				return url;
+			}
 		} else {
 			return null;
 		}

--- a/json-overlay/src/main/java/com/reprezen/jsonoverlay/ReferenceRegistry.java
+++ b/json-overlay/src/main/java/com/reprezen/jsonoverlay/ReferenceRegistry.java
@@ -7,8 +7,6 @@ import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Optional;
 
-import org.apache.commons.lang3.tuple.Pair;
-
 import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
 

--- a/json-overlay/src/main/java/com/reprezen/jsonoverlay/gen/CodeGenerator.java
+++ b/json-overlay/src/main/java/com/reprezen/jsonoverlay/gen/CodeGenerator.java
@@ -13,13 +13,11 @@ package com.reprezen.jsonoverlay.gen;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.util.Arrays;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.commons.lang3.StringUtils;
 import org.yaml.snakeyaml.Yaml;
 
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
@@ -85,7 +83,7 @@ public class CodeGenerator {
 	}
 
 	private String getImplPackage() {
-		return StringUtils.join(Arrays.asList(opts.pkg, opts.classPackage), ".");
+		return opts.pkg + "." + opts.classPackage;
 	}
 
 	private File getIntfDir() {
@@ -93,7 +91,7 @@ public class CodeGenerator {
 	}
 
 	private String getIntfPackage() {
-		return StringUtils.join(Arrays.asList(opts.pkg, opts.interfacePackage), ".");
+		return opts.pkg + "." + opts.interfacePackage;
 	}
 
 	private static class Opts {

--- a/json-overlay/src/main/java/com/reprezen/jsonoverlay/gen/TypeData.java
+++ b/json-overlay/src/main/java/com/reprezen/jsonoverlay/gen/TypeData.java
@@ -21,8 +21,6 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.StringUtils;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class TypeData {
@@ -117,7 +115,7 @@ public class TypeData {
 
 		public String getIntfExtendsDecl() {
 			List<String> interfaces = extendInterfaces != null ? extendInterfaces : typeData.defaultExtendInterfaces;
-			return interfaces != null ? " extends " + StringUtils.join(interfaces, ", ") : "";
+			return interfaces != null ? " extends " + interfaces.stream().collect(Collectors.joining(",")) : "";
 		}
 
 		public String getName() {

--- a/json-overlay/src/test/java/com/reprezen/jsonoverlay/LocationTests.java
+++ b/json-overlay/src/test/java/com/reprezen/jsonoverlay/LocationTests.java
@@ -8,7 +8,6 @@ import java.nio.charset.Charset;
 import java.util.Map;
 import java.util.Optional;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Test;
 
 import com.fasterxml.jackson.core.JsonPointer;


### PR DESCRIPTION
With it went a couple of apache libraries, so to make up for it we now
have our own Pair class, and we've gotten rid of our uses of apache
common-lang3.