### PR TITLE
ZEN-4682 Use maven-release-plugin

### DIFF
--- a/json-overlay/pom.xml
+++ b/json-overlay/pom.xml
@@ -1,15 +1,15 @@
 <!-- Copyright (c) 2017 ModelSolv, Inc. and others. All rights reserved. 
-	This program and the accompanying materials are made available under the 
-	terms of the Eclipse Public License v1.0 which accompanies this distribution, 
-	and is available at http://www.eclipse.org/legal/epl-v10.html Contributors: 
-	ModelSolv, Inc. - initial API and implementation and/or initial documentation -->
+	 This program and the accompanying materials are made available under the 
+	 terms of the Eclipse Public License v1.0 which accompanies this distribution, 
+	 and is available at http://www.eclipse.org/legal/epl-v10.html Contributors: 
+	 ModelSolv, Inc. - initial API and implementation and/or initial documentation -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.reprezen.jsonoverlay</groupId>
 	<artifactId>jsonoverlay</artifactId>
-	<version>4.0.1</version>
+	<version>4.0.2-SNAPSHOT</version>
 	<name>${project.groupId}:${project.artifactId}</name>
 	<description>JsonOverlay Framework</description>
 	<url>https://github.com/RepreZen/JsonOverlay</url>
@@ -197,6 +197,18 @@
 					</execution>
 				</executions>
 			</plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>2.5.3</version>
+                <configuration>
+                    <tagNameFormat>v@{project.version}</tagNameFormat>
+                    <autoVersionSubmodules>true</autoVersionSubmodules>
+                    <!-- We don't use release:perform - deployment is done in TeamCity. 
+						This just makes an errant perform operation harmless -->
+                    <goals>clean</goals>
+                </configuration>
+            </plugin>
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>


### PR DESCRIPTION
Going forward, release management will use the
maven-release-plugin. We'll no longer use date-time stamps as version
qualifiers.

Version releases will be performed directly in master branch. PRs should
never change project version.

We have disabled the release:perform goal, becuase we do deployments
from RepreZen's (private) TeamCity installation. That may change in the
future.

Proper sequence to move to a new release is:
* Be in master branch
* run: mvn release:prepare, specifying new release as appropriate and
  accepting defaults for everything else
* run mvn release:clean
* push to github