### PR TITLE
Task/zen 4675 Configure for snapshots

### DIFF
--- a/json-overlay/pom.xml
+++ b/json-overlay/pom.xml
@@ -196,6 +196,15 @@
 			</plugin>
 		</plugins>
 	</build>
+    <distributionManagement>
+        <snapshotRepository>
+            <uniqueVersion>false</uniqueVersion>
+            <id>sonatype-nexus-snapshots</id>
+            <name>Sonatype OSS Snapshots</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <layout>legacy</layout>
+        </snapshotRepository>
+    </distributionManagement>
 	<properties>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>

--- a/json-overlay/pom.xml
+++ b/json-overlay/pom.xml
@@ -97,6 +97,18 @@
 				</plugins>
 			</build>
 		</profile>
+		<profile>
+			<id>snap</id>
+			<repositories>
+				<repository>
+					<id>sonatype-snapshots</id>
+					<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+					<layout>default</layout>
+					<releases><enabled>false</enabled></releases>
+					<snapshots><enabled>true</enabled></snapshots>
+				</repository>
+			</repositories>
+		</profile>
 	</profiles>
 	<build>
 		<plugins>


### PR DESCRIPTION
Deployment to sonatype snapshots is enabled, and a new profile causes that repo to be made available for snapshot dependencies